### PR TITLE
fix: lazy looting error

### DIFF
--- a/PickIt.cs
+++ b/PickIt.cs
@@ -334,6 +334,11 @@ public partial class PickIt : BaseSettingsPlugin<PickItSettings>
                         && DoWePickThis(x)
                         && (Settings.PickUpWhenInventoryIsFull || CanFitInventory(x)))
             .MinBy(x => x.Distance);
+        
+        if(pickUpThisItem == null)
+        {
+            return true;
+        }
 
         var workMode = GetWorkMode();
         if (workMode == WorkMode.Manual || workMode == WorkMode.Lazy && ShouldLazyLoot(pickUpThisItem))


### PR DESCRIPTION
`pickUpThisItem` was `null`, which would pass to `ShouldLazyLoot(pickUpThisItem)` and caused it to spam logs.